### PR TITLE
Add missing `workgroup` in IHO M-1

### DIFF
--- a/sources/m1/document.adoc
+++ b/sources/m1/document.adoc
@@ -8,7 +8,7 @@
 :copyright-year: 2017
 :status: in-force
 :committee: hssc
-:workgroup:
+:workgroup: spwg
 :mn-document-class: iho
 :mn-output-extensions: xml,html,doc,pdf,rxl
 :local-cache-only:


### PR DESCRIPTION
As noticed in https://github.com/metanorma/mn-samples-iho/issues/68, `workgroup` attribute was missing. Added in this PR.